### PR TITLE
feat: Add missing features for distributing flexbe_app as a Debian package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,43 +3,21 @@ project(flexbe_app)
 
 find_package(catkin REQUIRED)
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-#catkin_python_setup()
-
-# specify catkin-specific information
-# INCLUDE_DIRS - The exported include paths (i.e. cflags) for the package
-# LIBRARIES - The exported libraries from the project
-# CATKIN_DEPENDS - Other catkin projects that this project depends on
-# DEPENDS - Non-catkin CMake projects that this project depends on
-# CFG_EXTRAS - Additional configuration options 
 catkin_package(
     INCLUDE_DIRS src
     LIBRARIES ${PROJECT_NAME})
 
-# use add_library() or add_executable() as required
-#add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})
-
-#FILE(GLOB BIN_FILES "bin/*")
-
-# install executables
-#install(PROGRAMS ${BIN_FILES} DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-#install(DIRECTORY launch DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
-#add_custom_target(nwjs_inst)
-#add_custom_command(TARGET nwjs_inst POST_BUILD COMMAND bin/nwjs_install)
-
-add_custom_command(OUTPUT nw
-  COMMAND bin/nwjs_install
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  VERBATIM
-)
-
-add_custom_target(nw_install DEPENDS nw)
-
-if(NOT ${CMAKE_CURRENT_SOURCE_DIR}/nw)
-  safe_execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/nwjs_install)
-endif()
-
 execute_process(COMMAND npm --prefix ${PROJECT_SOURCE_DIR} install)
+
+install(PROGRAMS bin/run_app
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+install(FILES package.json
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+install(DIRECTORY
+  node_modules
+  launch
+  src
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS)

--- a/bin/run_app
+++ b/bin/run_app
@@ -1,11 +1,4 @@
 #!/bin/bash
-cd "$( dirname "${BASH_SOURCE[0]}" )"
-
-if [ ! -f ../nw ]; then
-  echo "Cannot run flexbe_app, need to download nwjs first."
-  echo "Please build flexbe_app via catkin before using it or run the following command now:"
-  echo "  rosrun flexbe_app nwjs_install"
-  exit -1
-fi
-
-../nw --password-store=basic $*
+pkg_path="$(rospack find flexbe_app)"
+cd ${pkg_path}
+npm start

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "min_height": 650
   },
   "dependencies" : {
-    "scp2" : "^0.5.0"
+    "scp2" : "^0.5.0",
+    "nw" : "0.27.2"
+  },
+  "scripts": {
+    "start": "nw --password-store=basic $*"
   }
 }

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
-<package>
+<package format="2">
   <name>flexbe_app</name>
-  <version>2.0.6</version>
+  <version>2.1.0</version>
   <description>
      flexbe_app provides a user interface (editor + runtime control) for the FlexBE behavior engine.
   </description>
@@ -12,8 +12,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <run_depend>rospy</run_depend>
-  <run_depend>genpy</run_depend>
-  <run_depend>actionlib</run_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>genpy</exec_depend>
+  <exec_depend>actionlib</exec_depend>
+  <depend>npm</depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,9 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>genpy</exec_depend>
   <exec_depend>actionlib</exec_depend>
+  <exec_depend>flexbe_mirror</exec_depend>
+  <exec_depend>flexbe_widget</exec_depend>
+  <exec_depend>flexbe_onboard</exec_depend>
   <depend>npm</depend>
 
 </package>


### PR DESCRIPTION
## What I did:
- Added **nw** to list of module dependencies in **package.json** so it will be simply installed in addition to other dependencies.
- Also configured the start script of the module which will execute `nw`.
- Changed run_app script in a way that it will simply execute the module by using `npm start` command.
- The required files for using `nw` will be installed on `${CATKIN_PACKAGE_SHARE_DESTINATION}`
- Also, the **run_app** script and also launch directory will be properly installed
- **npm** is added as a run and also build dependency
- The **package.xml** format is changed to version 2

## How I tested:
By using bloom_generate and installing the resulting debian on my laptop